### PR TITLE
fix: le challenge ne correspondait pas au test

### DIFF
--- a/03-Handlers/challenge/README.md
+++ b/03-Handlers/challenge/README.md
@@ -14,7 +14,7 @@ Ansible en modifiant un fichier de configuration d'un service et en
 
 1. Créez un playbook `rsyslog-cron.yml`
 2. Ajoutez une tâche qui utilise le module `lineinfile` pour decommenter la ligne
-   `#cron.* /var/log/cron.log` dans le fichier `/etc/rsyslog.conf`. La tâche doit
+   `#cron.* /var/log/cron.log` dans le fichier `/etc/rsyslog.d/50-default.conf`. La tâche doit
    ressembler à :
 3. Assurez-vous que cette tâche notifie un handler `Restart rsyslog`
 4. Dans la section `handlers`, définissez le handler `Restart rsyslog` qui
@@ -22,9 +22,9 @@ Ansible en modifiant un fichier de configuration d'un service et en
 
 ## 👍 Critères de réussite
 
-Le test `test_handler_rsyslog.py` vérifiera que :
+Le test `test_rsyslog.py` vérifiera que :
 
-* Le fichier `/etc/rsyslog.conf` contient bien la ligne attendue
+* Le fichier `/etc/rsyslog.d/50-default.conf` contient bien la ligne attendue
 * Le service `rsyslog` est actif et fonctionne
 * Le handler est bien exécuté **seulement** si le fichier était modifié
 * Le playbook est **idempotent** (aucun changement à la 2e exécution)
@@ -34,7 +34,7 @@ Le test `test_handler_rsyslog.py` vérifiera que :
 Lancez le test avec la commande suivante :
 
 ```bash
-pytest -v challenge/tests/test_handler_rsyslog.py
+pytest -v tests/test_rsyslog.py
 ```
 
 Le test doit passer sans erreurs, comme ceci :


### PR DESCRIPTION
Modification des noms de fichiers pour correspondre à l'attendu du fichier test. Correction du chemin vers le fichier de test.