### PR TITLE
fix: patch regex bug inet local

### DIFF
--- a/03-Handlers/tests/test_rsyslog.py
+++ b/03-Handlers/tests/test_rsyslog.py
@@ -9,7 +9,7 @@ def get_server1_ip():
         ["incus", "info", "server1"], capture_output=True, text=True, check=True
     )
     # Rechercher l'IP IPv4 dans la sortie
-    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", result.stdout)
+    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/.* \(global\)", result.stdout)
     assert m, "Impossible de trouver l'IP IPv4 de server1"
     return m.group(1)
 

--- a/07-Conditions/challenge/tests/test_conditions.py
+++ b/07-Conditions/challenge/tests/test_conditions.py
@@ -9,7 +9,7 @@ def get_server1_ip():
         ["incus", "info", "myhost"], capture_output=True, text=True, check=True
     )
     # Rechercher l'IP IPv4 dans la sortie
-    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", result.stdout)
+    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/.* \(global\)", result.stdout)
     assert m, "Impossible de trouver l'IP IPv4 de server1"
     return m.group(1)
 

--- a/08-Roles/challenge/tests/test_rsyslog.py
+++ b/08-Roles/challenge/tests/test_rsyslog.py
@@ -9,7 +9,7 @@ def get_server1_ip():
         ["incus", "info", "server1"], capture_output=True, text=True, check=True
     )
     # Rechercher l'IP IPv4 dans la sortie
-    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", result.stdout)
+    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/.* \(global\)", result.stdout)
     assert m, "Impossible de trouver l'IP IPv4 de server1"
     return m.group(1)
 


### PR DESCRIPTION
## Description du bug

Ce bug a été découvert lors de travaux de recherche sur un pytest pour la partie 04-Templates.
Dans le TP actuel il manquait la partie vérification distante des droits sur les répertoires et fichiers mis en place.

## Moyen de reproduire

```bash
# Lancer la commande plusieurs fois de suite
ansible@devops-srv:~/ansible-training$ incus info webserver1
```
> L'ordre d'affichage des interfaces inet change 

## Symptôme

La regex : inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/ selectionne les 2 adresses IP (eth0 et lo). [regex101 v1](https://regex101.com/r/Q5Ct1D/1)
Suivant l'ordre d'affichage la dernière IP est selectionnée, donc soit eth0 où lo ce qui peut générer une erreur.

## Solution

Vérification de la nouvelle regex ici : [regex101 v2](https://regex101.com/r/ICMDVy/1)