### PR TITLE
fix: ajout groupe ubuntu au fichier incus.yml

### DIFF
--- a/07-Conditions/incus.yml
+++ b/07-Conditions/incus.yml
@@ -1,6 +1,9 @@
 ---
 plugin: kmpm.incus.incus
 groupby:
+  ubuntu:
+    type: os
+    attribute: Ubuntu
   debian:
     type: os
     attribute: Debian


### PR DESCRIPTION
Les groupes ne sont pas utilisés ici mais pour l'inventaire dynamique, ubuntu était manquant dans le fichier incus.yml.