### PR TITLE
fix: 08-Roles - Patch etape1 demo erreur

### DIFF
--- a/07-Conditions/challenge/README.md
+++ b/07-Conditions/challenge/README.md
@@ -10,7 +10,7 @@ conditions sont remplies** sur la machine cible `myhost` (créée via Incus).
 
 ## 📚 Contexte de test
 
-La machine cible s'appelle `myhost` et doit être lancée avec la commande suivante :
+La machine cible s'appelle `myhost` et doit être lancée avec les commandes suivantes :
 
 ```bash
 incus rm myhost --force
@@ -18,20 +18,20 @@ incus launch images:ubuntu/24.04/cloud myhost --config=cloud-init.user-data="$(c
 incus file push ~/.ssh/id_ed25519.pub myhost/home/admin/.ssh/authorized_keys
 ```
 
-**Note**: Remplacez `~/.ssh/id_ed25519.pub` par le chemin de votre clé publique SSH si
-vous utilisez une autre clé.
+**Note**:
+- Remplacez `~/.ssh/id_ed25519.pub` par le chemin de votre clé publique SSH si vous utilisez une autre clé.
+- Une autre solution consiste à réutiliser votre playbook de configuration de ssh de la partie `03-Handlers`.
 
 ## 🎓 Objectif
 
 Votre playbook nommé `challenge.yml` devra :
 
-1. Créer le group `developers` s'il n'existe pas
-2. Installer le serveur ssh sur la machine cible
-   (utilisez le module `ansible.builtin.package` avec `name: openssh-server`)
+1. Tester vos expressions avant exécution
+2. Créer le group `developers` s'il n'existe pas
 3. **Créer un fichier `/tmp/flag_condition.txt`** si deux conditions sont
    remplies :
-    * Le fact `ansible_os_family` de la vm est **Debian**
-    * Le groupe `developers` existe
+    * Le fact `ansible_distribution` de la vm est **Ubuntu**
+    * La tâche de création du groupe `developers` s'est bien exécutée.
   Sinon, le fichier **ne doit pas exister**.
 
 **Note** : Vous pouvez détruire et recréer la machine cible à chaque
@@ -43,8 +43,15 @@ Des tests automatisés sont disponibles.
 
 Ils vérifient que :
 
-* Que nous sommes bien en présence d'une distribution Ubuntu
-* Le fichier est bien créé
+* Le fichier `challenge.yml` contient bien les éléments suivants:
+  * Une vérification des variables avec `ansible.builtin.debug:`
+  * La création du groupe avec `ansible.builtin.group`
+  * L'utilisation de `register`pour enregistrer le resultat de l'execution d'une tâche
+  * L'utilisation de conditions avec `when`
+  * La recherche de `Ubuntu` dans la variable `ansible_distribution`
+* Nous sommes bien en présence d'une distribution `Ubuntu`
+* Le groupe `developers` existe bien
+* Le fichier `/tmp/flag_condition.txt` est bien créé
 
 Lancez la validation avec :
 
@@ -60,22 +67,36 @@ platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /home/outscale/.
 cachedir: .pytest_cache
 rootdir: /home/outscale/Projets/ansible-training/07-Conditions
 plugins: testinfra-10.2.2
-collected 3 items
+collected 4 items
 
-challenge/tests/test_conditions.py::test_file_exists PASSED       [ 33%]
-challenge/tests/test_conditions.py::test_distribution PASSED      [ 66%]
-challenge/tests/test_conditions.py::test_group_exists PASSED      [100%]
+challenge/tests/test_conditions.py::test_local_challenge_contains_required_facts PASSED       [ 25%]
+challenge/tests/test_conditions.py::test_remote_distribution PASSED                           [ 50%]
+challenge/tests/test_conditions.py::test_remote_group_exists PASSED                           [ 75%]
+challenge/tests/test_conditions.py::test_remote_file_exists PASSED                            [100%]
 
-=== 3 passed in 0.85s ===
+=== 4 passed in 1.24s ===
 ```
 
 ## ✅ Conseils
 
-* Utilisez le module `ansible.builtin.group` pour créer le groupe `developers`
-* Utilisez la commande `getent` pour vérifier la présence du groupe
-* Ajoutez un `debug:` pour tester vos expressions avant exécution
+* Utilisez un `ansible.builtin.debug:` pour tester vos expressions avant exécution
+* Utilisez le module `ansible.builtin.group:` pour créer le groupe `developers`
+* Utilisez `register:` pour définir une variable qui va stocker le résultat de la tache
 * Utilisez `when:` avec une condition combinée (et logique)
 
 ---
 
 Bonne chance ! 🎉
+
+<details>
+  <summary>Cliquer pour de l'aide supplémentaire</summary>
+  
+  #### Ressource supplémentaire :
+  
+  - 🔗 [Aide Ansible - conditions pour les variables enregistrées](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#conditions-based-on-registered-variables)
+
+* Utilisez `register:` pour définir une variable qui va stocker le résultat de la tâche.
+* Dans la clause `when:` controler la distribution **et** vérifier que la tache s'est bien exécutée grace à cette variable.
+* La clause `is succeeded` peut servir a vérifier que la tâche s'est bien déroulée.
+
+</details>

--- a/07-Conditions/challenge/tests/test_conditions.py
+++ b/07-Conditions/challenge/tests/test_conditions.py
@@ -2,6 +2,20 @@ import subprocess
 import re
 import pytest
 import testinfra
+import os
+
+def test_local_challenge_contains_required_facts():
+    challenge_path = os.path.join("challenge.yml")
+    assert os.path.exists(challenge_path), "Le fichier challenge.yml est manquant"
+
+    with open(challenge_path) as f:
+        content = f.read()
+        assert "ansible.builtin.debug:" in content
+        assert "ansible.builtin.group:" in content
+        assert "register:" in content
+        assert "when:" in content
+        assert "Ubuntu" in content
+        assert "is succeeded" in content
 
 def get_server1_ip():
     # Exécuter la commande incus info
@@ -18,12 +32,12 @@ def host():
     ip = get_server1_ip()
     return testinfra.get_host(f"ssh://admin@{ip}")
 
-def test_file_exists(host):
-    assert host.file("/tmp/flag_condition.txt").exists, "Le fichier /tmp/flag_condition.txt n'existe pas"
-
-def test_distribution(host):
+def test_remote_distribution(host):
     assert host.system_info.distribution == "ubuntu", "La distribution n'est pas Ubuntu"
     assert host.system_info.release.startswith("24.04"), "La version n'est pas 24.04"
 
-def test_group_exists(host):
+def test_remote_group_exists(host):
     assert host.group("developers").exists, "Le groupe 'developers' n'existe pas"
+
+def test_remote_file_exists(host):
+    assert host.file("/tmp/flag_condition.txt").exists, "Le fichier /tmp/flag_condition.txt n'existe pas"

--- a/08-Roles/README.md
+++ b/08-Roles/README.md
@@ -70,6 +70,7 @@ ansible-galaxy init roles/sshd
     line: 'PermitRootLogin no'
     state: present
     backup: true
+  notify: Redémarrer ssh
 ```
 
 4. Editez le fichier `roles/sshd/handlers/main.yml` avec le contenu suivant :
@@ -87,7 +88,7 @@ ansible-galaxy init roles/sshd
 ```yaml
 ---
 - name: Test du rôle sshd
-  hosts: server1
+  hosts: servers
   become: true
   roles:
     - sshd
@@ -119,7 +120,7 @@ permit_root_login: 'no'
 sshd_service: ssh
 ```
 
-2. Adaptez `tasks/main.yml` pour utiliser ces variables :
+2. Adaptez `roles/sshd/tasks/main.yml` pour utiliser ces variables :
 
 ```yaml
 - name: Installer le serveur SSH

--- a/08-Roles/incus.yml
+++ b/08-Roles/incus.yml
@@ -7,3 +7,6 @@ groupby:
   almalinux:
     type: os
     attribute: 'Almalinux'
+  servers:
+    type: pattern
+    attribute: '^server'


### PR DESCRIPTION
La description dans le `README.md` évoquait une erreur sur le server2, cependant avec la configuration `incus.yml` un seul serveur étaient utilisé. L'inventaire dynamique a été changé pour inclure les 2 serveurs et notifier en cas de redémarrage necessaire pour le service SSH configuré.