### PR TITLE
fix: patch inet regex

### DIFF
--- a/09-Blocks/challenge/tests/test_block.py
+++ b/09-Blocks/challenge/tests/test_block.py
@@ -9,7 +9,7 @@ def get_server1_ip():
         ["incus", "info", "server1"], capture_output=True, text=True, check=True
     )
     # Rechercher l'IP IPv4 dans la sortie
-    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", result.stdout)
+    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/.* \(global\)", result.stdout)
     assert m, "Impossible de trouver l'IP IPv4 de server1"
     return m.group(1)
 
@@ -36,7 +36,7 @@ def get_server2_ip():
     result = subprocess.run(
         ["incus", "info", "server2"], capture_output=True, text=True, check=True
     )
-    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)", result.stdout)
+    m = re.search(r"inet:\s*([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/.* \(global\)", result.stdout)
     assert m, "Impossible de trouver l'IP IPv4 de server2"
     return m.group(1)
 


### PR DESCRIPTION
Dernier pytest qui échoue par moment lorsque la recherche d'ip de la carte réseau renvoie `127.0.0.1` :

```bash
ansible@devops-svr:~/ansible-training/09-Blocks$ pytest -v
=== test session starts ===
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0 -- /home/ansible/.local/share/pipx/venvs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ansible/ansible-training/09-Blocks
plugins: testinfra-10.2.2
collected 4 items                                                                                                                                            

The authenticity of host '127.0.0.1 (127.0.0.1)' can't be established.rver1 
ED25519 key fingerprint is SHA256:PpYRRwbmDh9tihw4Rvi/ki8rybSCcit9WB85wKSKc78.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
admin@127.0.0.1's password:
``` 