### PR TITLE
Ajout instructions installation python3-testinfra dans README

### DIFF
--- a/02-Playbooks/challenge/README.md
+++ b/02-Playbooks/challenge/README.md
@@ -52,6 +52,18 @@ commande suivante :
 ```bash
 pytest -v
 ```
+Assurez-vous d’avoir installé python3-testinfra pour pouvoir utiliser la commande ci-dessus.
+
+Pour l’installer, voici les commandes dont vous avez besoin :           
+
+```bash
+sudo apt update
+```
+
+```bash
+sudo apt install -y python3-testinfra
+```
+
 
 Résultat attendu :
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ sur les bonnes pratiques de contribution.
 
 ## ☕ Me soutenir
 
-Si vous trouvez ce guide utile et souhaitez me soutenir, vous pouvez me offrir
+Si vous trouvez ce guide utile et souhaitez me soutenir, vous pouvez m'offrir
 un café :
 
 [![Ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/votre-identifiant)


### PR DESCRIPTION
Lors de l’exécution de pytest -v, les tests définis dans challenge/tests/test_playbook.py échouent si python3-testinfra n’est pas installé.

J’ai donc complété le README.md avec les étapes d’installation de cette dépendance.

Avec python3-testinfra installé, les tests du fichier test_playbook.py s’exécutent correctement et passent tous.

Avant

![image.png](attachment:a14f079e-e7f8-4edd-8cd7-45092581bbb0:image.png)

Après 

![image.png](attachment:055af5de-c370-4127-93f7-fdc8b9993cc6:image.png)