### PR TITLE
Ajouter openssh dans le cloud-init.yaml

### DIFF
--- a/07-Conditions/challenge/README.md
+++ b/07-Conditions/challenge/README.md
@@ -10,11 +10,11 @@ conditions sont remplies** sur la machine cible `myhost` (créée via Incus).
 
 ## 📚 Contexte de test
 
-La machine cible s'appelle `myhost` et doit être lancée avec les commandes suivantes :
+La machine cible s'appelle `myhost` et doit être lancée avec les commandes suivantes à partir du dossier `/challenge` :
 
 ```bash
 incus rm myhost --force
-incus launch images:ubuntu/24.04/cloud myhost --config=cloud-init.user-data="$(cat ../cloud-config.yaml)"
+incus launch images:ubuntu/24.04/cloud myhost --config=cloud-init.user-data="$(cat ../../cloud-config.yaml)"
 incus file push ~/.ssh/id_ed25519.pub myhost/home/admin/.ssh/authorized_keys
 ```
 

--- a/cloud-config.yaml
+++ b/cloud-config.yaml
@@ -13,10 +13,13 @@ packages:
   - pipx
   - git
   - python3-venv
+  - openssh-server
 write_files:
   - path: /home/admin/.profile
     content: |
        export PATH=$PATH:/home/admin/.local/bin
     append: true
 runcmd:
+  - systemctl enable ssh
+  - systemctl start ssh
   - chown -R admin:admin /home/admin


### PR DESCRIPTION
## Ce que je constate comme erreur
Le challenge 07-conditions ne fonctionne pas avec les commandes incus fournies car `openssh-server` n'est pas installé sur la machine distante. Ainsi le lancement du test python ne permet pas de se connecter à la machine via ssh, malgré l'ajout de la clef publique (avec la commande précisée dans le README du challenge).

## Ce que je propose
- Modifier le `cloud-config.yaml` pour ajouter `openssh-server` dans les packages, puis de s'assurer de son lancement dans le `runcmd`.
- Puisque la commande `pytest -v` doit être lancée dans le folder `/challenge` pour détecter le fichier `challenge.yml`, je suppose que toutes les commandes précisées dans le README sont à lancer dans ce même folder. Ainsi j'ai précisé dans le README d'où doit-on lancer la commande et j'ai modifié la commande `incus launch` avec le bon path soit `../../cloud-config.yaml`. 
> Une autre solution pourrait-être de modifier le script Python pour regarder la présence de `/challenge/challenge.yml`. Toujours est-il que je pense qu'il faudrait mieux spécifier d'où lancer les commandes.