### PR TITLE
chore(ci): aligner la gouvernance sécurité sur linux-dsoxlab-training

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,15 @@
 # Default owner for everything in the repository. Pull requests require a
-# review from a code owner (enforced by branch protection on `main`).
+# review from a code owner (enforced by the ruleset on `main`).
 * @stephrobert
+
+# The CI/CD chain is the most sensitive surface in the repo: any change here can
+# exfiltrate secrets or weaken every other gate. Owned explicitly so a review is
+# always required, even if the default owner above is ever broadened.
+/.github/workflows/ @stephrobert
+/.github/dependabot.yml @stephrobert
+/.plumber.yaml @stephrobert
+/.poutine.yml @stephrobert
+/.pre-commit-config.yaml @stephrobert
+
+# Encrypted trainer solutions (ansible-vault): a leak here defeats every lab.
+/solution/ @stephrobert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           version: "1.26.1"
           advanced-security: false


### PR DESCRIPTION
- Ruleset de protection de main créé (miroir du ruleset « Protection de main » de linux-dsoxlab-training) : suppression et force-push interdits, historique linéaire, PR obligatoire, 5 status checks requis en strict (Zizmor, Actionlint, Poutine, Pre-commit parity, CodeQL). Posé via l'API rulesets, hors de ce commit.
- zizmor-action 0.5.7 -> 0.6.0, à parité avec linux.
- CODEOWNERS : propriété explicite de la chaîne CI/CD (workflows, dependabot, plumber, poutine, pre-commit) et des solutions chiffrées, pour qu'une revue soit toujours requise sur ces surfaces sensibles même si le propriétaire par défaut est un jour élargi.

La quarantaine Dependabot (cooldown 7 jours) était déjà en place sur les deux écosystèmes, inchangée.