### PR TITLE
feat(provision): enchaîner la config hosts + ssh dans mise run provis…

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -66,9 +66,9 @@ ANSIBLE_TRAINING = "{{ config_root }}"
 # sur la CLI ment au lecteur.
 
 [tasks.provision]
-description = "Monte les 4 VMs et prépare les managed nodes (dsoxlab + bootstrap)"
+description = "Monte les 4 VMs, prépare les managed nodes et rend le lab utilisable (hosts + ssh)"
 # `dsoxlab provision` crée des VMs NUES : cloud-init pose le compte et la clé,
-# rien de plus. Or les labs ciblent des managed nodes équipés — sans
+# rien de plus. Or les labs ciblent des managed nodes équipés : sans
 # python3-firewall, tout lab touchant au pare-feu échoue sur « Failed to import
 # the required Python library (firewall) ». Mesuré : 133 tests en échec sans
 # cette étape, 17 avec.
@@ -76,9 +76,18 @@ description = "Monte les 4 VMs et prépare les managed nodes (dsoxlab + bootstra
 # Le contrat dsoxlab n'a pas de crochet post-provision : le dépôt enchaîne donc
 # lui-même. `dsoxlab provision` seul reste valide, il laisse juste les nodes
 # nus.
+#
+# Les deux dernières étapes rendent le lab directement jouable après un seul
+# `mise run provision` (c'était la demande de l'issue #34) : résolution des noms
+# du lab dans /etc/hosts et fragment SSH dans ~/.ssh/config.d. Toutes deux sont
+# idempotentes (elles vérifient leur marqueur avant d'écrire), donc sans effet
+# si elles ont déjà tourné. Pour les jouer séparément : `mise run setup-hosts`
+# et `mise run setup-ssh` ; pour défaire : `mise run remove-hosts` / `remove-ssh`.
 run = [
     "dsoxlab provision",
     "ansible-playbook -i inventory/hosts.yml labs/bootstrap/prepare-managed-nodes/playbook.yml",
+    "./scripts/manage-hosts.sh add",
+    "./scripts/manage-ssh-config.sh add",
 ]
 
 [tasks.bootstrap-nodes]


### PR DESCRIPTION
…ion (#34)

L'issue #34 demandait qu'un seul provision rende le lab jouable : monter les VMs, mais aussi résoudre les noms du lab dans /etc/hosts et poser le fragment SSH du poste. La forme d'origine (un Makefile qui enchaînait provision, hosts-add et ssh-config-add) a disparu à la migration dsoxlab ; les tâches existaient depuis (setup-hosts, setup-ssh) mais séparées, donc à lancer à la main.

`mise run provision` enchaîne désormais, après le provisioning et la préparation des managed nodes, `manage-hosts.sh add` et `manage-ssh-config.sh add`. Les deux sont idempotentes (marqueur vérifié avant écriture), donc rejouables sans effet. Elles restent disponibles isolément (setup-hosts / setup-ssh) et réversibles (remove-hosts / remove-ssh).

Fixes #34