### PR TITLE
fix(lint): corriger les 36 signalements ruff au lieu de les écarter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -374,6 +374,7 @@ def _protect_lab_tree(request, lab_root: Path) -> None:
     res = subprocess.run(
         ["git", "ls-files", "-z", "--", str(lab_root)],
         cwd=REPO_ROOT, capture_output=True,
+        check=False,
     )
     if res.returncode != 0:
         return  # hors dépôt git : rien à protéger
@@ -463,8 +464,14 @@ def _lab_key(lab_root: Path) -> str:
 
 
 def _run(cmd, **kwargs):
-    """Exécute une commande, lève en cas d'échec avec stdout/stderr lisibles."""
-    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+    """Exécute une commande, lève en cas d'échec avec stdout/stderr lisibles.
+
+    Ne pas lui passer `check` : c'est cette fonction qui décide de lever, et
+    son message vaut mieux que le `CalledProcessError` de subprocess, qui perd
+    stdout et stderr. Un `check=` dans les kwargs lève un TypeError immédiat,
+    ce qui est le bon moment pour l'apprendre.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs, check=False)
     if result.returncode != 0:
         raise RuntimeError(
             f"Commande échouée (exit {result.returncode}) : {' '.join(cmd)}\n"
@@ -534,6 +541,7 @@ def _domain_disks(domain: str) -> list[str]:
     res = subprocess.run(
         ["sudo", "virsh", "domblklist", domain, "--details"],
         capture_output=True, text=True,
+        check=False,
     )
     disks: list[str] = []
     for line in res.stdout.splitlines():
@@ -571,6 +579,7 @@ def _domain_uuid(fqdn: str) -> str | None:
     """UUID du domaine libvirt tel qu'il existe MAINTENANT, ou None."""
     res = subprocess.run(
         ["sudo", "virsh", "domuuid", fqdn], capture_output=True, text=True,
+        check=False,
     )
     return res.stdout.strip() or None
 
@@ -580,6 +589,7 @@ def _saved_image_uuid(path: str) -> str | None:
     res = subprocess.run(
         ["sudo", "virsh", "save-image-dumpxml", path],
         capture_output=True, text=True,
+        check=False,
     )
     if res.returncode != 0:
         return None
@@ -641,6 +651,7 @@ def _wait_ssh(fqdns: list[str], timeout: int = 240) -> None:
                  "-o", "BatchMode=yes", fqdn,
                  "systemctl is-system-running 2>/dev/null || true"],
                 capture_output=True, text=True,
+                check=False,
             )
             if probe.stdout.strip() in ("running", "degraded"):
                 break
@@ -658,7 +669,7 @@ def snapshot_base(fqdns: list[str]) -> None:
     neuf pour que l'état figé parte propre).
     """
     for fqdn in fqdns:
-        subprocess.run(["sudo", "virsh", "destroy", fqdn], capture_output=True)
+        subprocess.run(["sudo", "virsh", "destroy", fqdn], capture_output=True, check=False)
         for disk in _domain_disks(fqdn):
             base = _base_path(disk)
             if not Path(base).exists():
@@ -706,7 +717,7 @@ def snapshot_reset(fqdns: list[str]) -> bool:
             and _golden_is_usable(fqdn, mem)
         ):
             reset_any = True
-            subprocess.run(["sudo", "virsh", "destroy", fqdn], capture_output=True)
+            subprocess.run(["sudo", "virsh", "destroy", fqdn], capture_output=True, check=False)
             for disk in disks:
                 tmp = disk + ".new"
                 _run(["sudo", "cp", disk + ".postboot", tmp])
@@ -719,7 +730,7 @@ def snapshot_reset(fqdns: list[str]) -> bool:
         if not all(Path(b).exists() for _, b in pairs):
             continue
         reset_any = True
-        subprocess.run(["sudo", "virsh", "destroy", fqdn], capture_output=True)
+        subprocess.run(["sudo", "virsh", "destroy", fqdn], capture_output=True, check=False)
         for disk, base in pairs:
             tmp = disk + ".new"
             _run(["sudo", "qemu-img", "create", "-f", "qcow2", "-F", "qcow2",
@@ -766,6 +777,7 @@ def _resync_clocks(fqdns: list[str]) -> None:
              fqdn, f"sudo -n date -s @{int(time.time())}"],
             capture_output=True,
             timeout=30,
+            check=False,
         )
 
 

--- a/labs/collections/ci-tests/challenge/tests/test_functional.py
+++ b/labs/collections/ci-tests/challenge/tests/test_functional.py
@@ -44,7 +44,7 @@ def test_github_workflow_pins_actions_by_sha():
 
 def test_github_workflow_matrix_has_two_ansible_versions():
     data = yaml.safe_load(GH_WORKFLOW.read_text())
-    sanity_job = data["jobs"].get("sanity") or list(data["jobs"].values())[0]
+    sanity_job = data["jobs"].get("sanity") or next(iter(data["jobs"].values()))
     matrix = sanity_job.get("strategy", {}).get("matrix", {})
     ansible_versions = matrix.get("ansible", [])
     assert len(ansible_versions) >= 2, (
@@ -54,7 +54,7 @@ def test_github_workflow_matrix_has_two_ansible_versions():
 
 def test_github_workflow_matrix_has_two_python_versions():
     data = yaml.safe_load(GH_WORKFLOW.read_text())
-    sanity_job = data["jobs"].get("sanity") or list(data["jobs"].values())[0]
+    sanity_job = data["jobs"].get("sanity") or next(iter(data["jobs"].values()))
     python_versions = sanity_job.get("strategy", {}).get("matrix", {}).get("python", [])
     assert len(python_versions) >= 2, (
         f"La matrice doit contenir ≥2 versions de Python, vu : {python_versions}"

--- a/labs/decouvrir/installation-ansible/challenge/tests/test_functional.py
+++ b/labs/decouvrir/installation-ansible/challenge/tests/test_functional.py
@@ -97,6 +97,7 @@ def test_solution_script_returns_zero():
         capture_output=True,
         text=True,
         timeout=30,
+        check=False,
     )
     assert result.returncode == 0, (
         f"solution.sh a échoué (exit {result.returncode}).\n"

--- a/labs/decouvrir/prise-en-main-cli/challenge/tests/test_functional.py
+++ b/labs/decouvrir/prise-en-main-cli/challenge/tests/test_functional.py
@@ -50,6 +50,7 @@ def test_solution_script_returns_zero():
         capture_output=True,
         text=True,
         timeout=30,
+        check=False,
     )
     assert result.returncode == 0, (
         f"solution.sh a échoué (exit {result.returncode}).\n"

--- a/labs/ecrire-code/any-errors-fatal/challenge/tests/test_functional.py
+++ b/labs/ecrire-code/any-errors-fatal/challenge/tests/test_functional.py
@@ -55,7 +55,7 @@ def _run_solution(extra_args=None):
     playbook, vault_args = lab_playbook(__file__)
     cmd = ["ansible-playbook", *vault_args, str(playbook)]
     cmd += extra_args or []
-    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
 
 
 def _step1(host):

--- a/labs/inventaires/dynamique-kvm/challenge/tests/test_functional.py
+++ b/labs/inventaires/dynamique-kvm/challenge/tests/test_functional.py
@@ -57,6 +57,7 @@ def test_pattern_ne_cible_que_les_vms_du_lab():
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert res.returncode == 0, (
         f"`ansible {PATTERN} --list-hosts` a échoué :\n{res.stderr}"

--- a/labs/inventaires/patterns-hotes/challenge/tests/test_functional.py
+++ b/labs/inventaires/patterns-hotes/challenge/tests/test_functional.py
@@ -61,6 +61,7 @@ def _run_playbook(limit_pattern):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(

--- a/labs/inventaires/statiques/challenge/tests/test_functional.py
+++ b/labs/inventaires/statiques/challenge/tests/test_functional.py
@@ -41,6 +41,7 @@ def _inventory_list():
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert res.returncode == 0, (
         "ansible-inventory n'a pas su lire l'inventaire du lab :\n"
@@ -56,6 +57,7 @@ def _inventory_host(host):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert res.returncode == 0, (
         f"ansible-inventory --host {host} a échoué :\n"
@@ -72,6 +74,7 @@ def _ping(pattern):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
 
 

--- a/labs/pratiques/ansible-pull-gitops/challenge/tests/test_functional.py
+++ b/labs/pratiques/ansible-pull-gitops/challenge/tests/test_functional.py
@@ -61,6 +61,7 @@ def _run_solution():
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(

--- a/labs/pratiques/versionner-git/challenge/tests/test_functional.py
+++ b/labs/pratiques/versionner-git/challenge/tests/test_functional.py
@@ -34,6 +34,7 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
         ["git", "-C", str(repo), *args],
         capture_output=True,
         text=True,
+        check=False,
     )
 
 
@@ -54,6 +55,7 @@ def run_solution() -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         timeout=120,
+        check=False,
     )
 
 

--- a/labs/rhce/mock-ex294-2/challenge/tests/test_functional.py
+++ b/labs/rhce/mock-ex294-2/challenge/tests/test_functional.py
@@ -85,7 +85,7 @@ def _lancer_solution(*args_supplementaires):
     cmd += list(args_supplementaires)
     env = os.environ.copy()
     env.update(_roles_path(_LAB_ROOT))
-    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, env=env)
+    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, env=env, check=False)
 
 
 def _recap_de(sortie, hote):
@@ -115,6 +115,7 @@ def _facts_locaux(hote):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert res.returncode == 0, (
         f"La collecte de facts a échoué sur {hote} :\n"
@@ -149,6 +150,7 @@ def test_01_inventory_groups(db1, web1):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert graph.returncode == 0, (
         "ansible-inventory n'a pas su lire l'inventaire du lab :\n"
@@ -175,6 +177,7 @@ def test_01_inventory_groups(db1, web1):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert ping.returncode == 0, (
         "Les 3 hôtes doivent répondre au ping Ansible à travers VOTRE "
@@ -751,7 +754,7 @@ def test_17_les_tags_selectionnent_vraiment_les_taches(db1):
     )
 
     db1.check_output("sh -c 'rm -f /tmp/lab200-tag-*.txt'")
-    for nom, chemin in _MARQUEURS_TAGS.items():
+    for chemin in _MARQUEURS_TAGS.values():
         assert not db1.file(chemin).exists, f"Table rase incomplète : {chemin}"
 
     res = _lancer_solution("--tags", "publish")

--- a/labs/rhce/mock-ex294/challenge/tests/test_functional.py
+++ b/labs/rhce/mock-ex294/challenge/tests/test_functional.py
@@ -105,7 +105,7 @@ def _lancer_solution(*args_supplementaires):
     cmd += list(args_supplementaires)
     env = os.environ.copy()
     env.update(_roles_path(_LAB_ROOT))
-    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, env=env)
+    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, env=env, check=False)
 
 
 def _recap_de(sortie, hote):
@@ -148,6 +148,7 @@ def _facts_locaux(hote):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert res.returncode == 0, (
         f"La collecte de facts a échoué sur {hote} :\n"
@@ -196,6 +197,7 @@ def test_01_inventory_groups(db1, web1):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert graph.returncode == 0, (
         "ansible-inventory n'a pas su lire l'inventaire du lab :\n"
@@ -222,6 +224,7 @@ def test_01_inventory_groups(db1, web1):
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        check=False,
     )
     assert ping.returncode == 0, (
         "Les 3 hôtes doivent répondre au ping Ansible à travers VOTRE "
@@ -920,7 +923,7 @@ def test_17_les_tags_selectionnent_vraiment_les_taches(db1):
     )
 
     db1.check_output("sh -c 'rm -f /tmp/lab100-tag-*.txt'")
-    for nom, chemin in _MARQUEURS_TAGS.items():
+    for chemin in _MARQUEURS_TAGS.values():
         assert not db1.file(chemin).exists, f"Table rase incomplète : {chemin}"
 
     res = _lancer_solution("--tags", "deploiement")

--- a/labs/roles/argument-specs/challenge/tests/test_functional.py
+++ b/labs/roles/argument-specs/challenge/tests/test_functional.py
@@ -85,6 +85,7 @@ def test_invalid_choice_makes_play_fail():
         capture_output=True,
         text=True,
         env=env,
+        check=False,
     )
     # On attend un échec (rc != 0) avec le message de validation
     assert result.returncode != 0, "argument_specs aurait dû rejeter la valeur invalide"

--- a/labs/roles/consommer-role/challenge/tests/test_functional.py
+++ b/labs/roles/consommer-role/challenge/tests/test_functional.py
@@ -56,6 +56,7 @@ def _converge():
         capture_output=True,
         text=True,
         env=env,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(

--- a/labs/roles/dependencies/challenge/tests/test_functional.py
+++ b/labs/roles/dependencies/challenge/tests/test_functional.py
@@ -105,6 +105,7 @@ def _converge(_meta_dependencies):
         capture_output=True,
         text=True,
         env=env,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,22 +6,15 @@ requires-python = ">=3.11"
 dependencies = []
 
 [tool.ruff.lint]
-# Sélection EXPLICITE, parce que l'absence de config ne veut pas dire « pas de
-# règles » : elle veut dire « celles que ruff décidera demain ». La 0.16.0 a
-# élargi son jeu par défaut (PL, PERF, RUF, S, B…) et a rougi la CI d'un dépôt
-# que personne n'avait touché.
+# Aucune règle écartée : on prend TOUT ce que ruff active par défaut. Ce qui est
+# figé, c'est la version — le hook épingle ruff@0.16.0, donc le jeu de règles ne
+# bouge plus sans qu'on le décide. C'est la version flottante qui avait rougi la
+# CI, pas les règles elles-mêmes.
 #
-# E4/E7/E9 + F : ce que ruff active par défaut, écrit noir sur blanc. Pas `E`
-# entier : il embarque E501 (longueur de ligne), et 96 lignes du catalogue la
-# dépassent — un test qui cite un chemin ou un message d'erreur complet est plus
-# lisible long que coupé. I : imports triés, ce que la 0.16.0 a imposé au
-# catalogue et qu'on garde, c'est lisible.
-#
-# Volontairement dehors : PLW1510 (`subprocess.run` sans `check`). Les tests de
-# labs inspectent le `returncode` ligne suivante — c'est la façon idiomatique
-# d'écrire un test, pas un oubli. Idem PERF102 et RUF015, micro-optimisations
-# sans objet dans du code pédagogique qui doit d'abord se lire.
-select = ["E4", "E7", "E9", "F", "I"]
+# `extend-select` plutôt que `select` : on ajoute à la sélection par défaut au
+# lieu de la remplacer, ce qui éviterait justement de désactiver des règles sans
+# s'en rendre compte.
+extend-select = ["I"]  # imports triés
 
 [tool.pytest.ini_options]
 # Le contrat dsoxlab impose que chaque lab nomme son test challenge/tests/


### PR DESCRIPTION
Le commit précédent restreignait la sélection de règles à E4/E7/E9/F/I, ce qui faisait disparaître PLW1510, PERF102 et RUF015 sans rien réparer. C'est un contournement, il est retiré : la configuration prend désormais TOUT ce que ruff active par défaut, plus le tri des imports, et rien n'est écarté. Le déterminisme vient de la version épinglée (ruff@0.16.0 dans le hook), pas d'un filtre sur les règles.

Les 36 sites sont corrigés :

- 32 PLW1510 : `check=False` explicite. Le choix est le même partout, et il est motivé — chaque appel inspecte lui-même son retour (assert sur `returncode`, `if returncode != 0: raise`, ou renvoi du CompletedProcess à l'appelant). Deux familles attendent même l'échec : `roles/argument-specs` passe une valeur invalide exprès, et les `virsh destroy` du conftest portent sur des domaines parfois déjà éteints. `check=True` y aurait changé le comportement.
- 2 PERF102 : boucle sur `.values()` là où la clé ne servait pas.
- 2 RUF015 : `next(iter(...))` au lieu de matérialiser la liste pour son premier élément.

`_run` du conftest gagne une note : ne pas lui passer `check`, c'est elle qui lève, et son message conserve stdout et stderr là où CalledProcessError les perd.

Insertion faite par l'AST, pas au sed : ces appels s'écrivent sur une ligne ou sur dix, avec ou sans virgule finale.

Vérifié : `ruff@0.16.0 check` vert sans aucune règle écartée, `pre-commit run --all-files` vert aux deux stages, 2469 tests de catalogue verts.